### PR TITLE
Update keyboard section

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -178,10 +178,10 @@ versions, including kits with all the needed parts included.
 
 ## Will a keyboard be included?
 
-Yes. A custom Perixx keyboard has been designed by Perifractic. Based on the
+Yes. A custom Perixx keyboard has been designed by Perifractic, based on the
 [PERIBOARD-409](https://perixx.com/products/periboard-409-u-w-wired-mini-keyboard-75-quiet-keys-in-white).
-The keyboard will resemble the late model Commodore 64C keyboard, WITH PETSCII
-glyphs, and a white case.
+The keyboard will resemble the late model Commodore 64C keyboard, with PETSCII
+glyphs and a white case.
 
 ## Why PS/2 Keyboard and not USB?
 

--- a/faq.md
+++ b/faq.md
@@ -179,7 +179,7 @@ versions, including kits with all the needed parts included.
 ## Will a keyboard be included?
 
 Yes. A custom Perixx keyboard has been designed by Perifractic, based on the
-[PERIBOARD-409](https://perixx.com/products/periboard-409?variant=46154180722947).
+[PERIBOARD-409](https://perixx.com/products/periboard-409?variant=46154180624643).
 The keyboard will resemble the late model Commodore 64C keyboard, with PETSCII
 glyphs and a white case.
 

--- a/faq.md
+++ b/faq.md
@@ -181,13 +181,7 @@ versions, including kits with all the needed parts included.
 Yes. A custom Perixx keyboard has been designed by Perifractic. Based on the
 [PERIBOARD-409](https://perixx.com/products/periboard-409-u-w-wired-mini-keyboard-75-quiet-keys-in-white).
 The keyboard will resemble the late model Commodore 64C keyboard, WITH PETSCII
-glyphs, and a white case. You can also order a
-[custom WASD keyboard](https://www.wasdkeyboards.com/commander16-by-the-8-bit-guy.html)
-with compatible PS/2 firmware and PETSCII keycaps.
-[PETSCII Keycaps](https://www.wasdkeyboards.com/commander16-by-the-8-bit-guy-87-key-custom-cherry-mx-keycap-set.html)
-are also available separately. The PETSCII keycaps work on an 80% or 104-key
-keyboard. (There are no PETSCII glpyhs for the numeric pad, but the numeric pad
-is now recognized by the KERNAL and produces the expected output.)
+glyphs, and a white case.
 
 ## Why PS/2 Keyboard and not USB?
 

--- a/faq.md
+++ b/faq.md
@@ -179,7 +179,7 @@ versions, including kits with all the needed parts included.
 ## Will a keyboard be included?
 
 Yes. A custom Perixx keyboard has been designed by Perifractic, based on the
-[PERIBOARD-409](https://perixx.com/products/periboard-409-u-w-wired-mini-keyboard-75-quiet-keys-in-white).
+[PERIBOARD-409](https://perixx.com/products/periboard-409?variant=46154180722947).
 The keyboard will resemble the late model Commodore 64C keyboard, with PETSCII
 glyphs and a white case.
 


### PR DESCRIPTION
I expect there's better ways of doing this, so feel free to cherry-pick commits or do it differently.

I've removed the reference to WASD entirely, since they are no longer in business. I think it just confuses matters and isn't a great look to have that there. One could make the argument it should be upfront about the fact those products are no longer available - see what you make of it.